### PR TITLE
imgui.ini: Fix for my flub in PR #2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,4 +55,4 @@ set(TEST_SOURCES
 
 add_executable(lldb-frontend-test ${TEST_SOURCES})
 target_compile_features(lldb-frontend-test PRIVATE cxx_std_23)
-file(COPY imgui.ini DESTINATION ${CMAKE_BINARY_DIR}/imgui.ini)
+file(COPY imgui.ini DESTINATION ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
#2 was critically flawed in that it copied `imgui.ini` into a folder called `imgui.ini` in the binary directory. That was wrong. Now it just copies into the binary directory.