### PR TITLE
CMake install and CPack plus actions artifacts

### DIFF
--- a/.github/workflows/push-run-actions.yml
+++ b/.github/workflows/push-run-actions.yml
@@ -60,24 +60,24 @@ jobs:
       - name: Build Package on Linux
         if: runner.os == 'Linux'
         run: |
-          cmake -G Ninja -B build -D CMAKE_BUILD_TYPE=Release -D CMAKE_C_COMPILER=clang -D CMAKE_CXX_COMPILER=clang++
-          cmake --build build --config Release
+          cmake -G Ninja -B build -D CMAKE_BUILD_TYPE=Debug -D CMAKE_C_COMPILER=clang -D CMAKE_CXX_COMPILER=clang++
+          cmake --build build --config Debug
           cpack --config build/CPackConfig.cmake
         shell: bash
 
       - name: Build Package on macOS
         if: runner.os == 'macOS'
         run: |
-          cmake -G Ninja -B build -D CMAKE_BUILD_TYPE=Release -D CMAKE_C_COMPILER=clang -D CMAKE_CXX_COMPILER=clang++ "-DLLVM_DIR=$(brew --prefix llvm)/lib/cmake/llvm"
-          cmake --build build --config Release
+          cmake -G Ninja -B build -D CMAKE_BUILD_TYPE=Debug -D CMAKE_C_COMPILER=clang -D CMAKE_CXX_COMPILER=clang++ "-DLLVM_DIR=$(brew --prefix llvm)/lib/cmake/llvm"
+          cmake --build build --config Debug
           cpack --config build/CPackConfig.cmake
         shell: bash
 
       - name: Build Package on Windows
         if: runner.os == 'Windows'
         run: |
-          cmake -G Ninja -B build -D CMAKE_BUILD_TYPE=Release -D CMAKE_C_COMPILER=clang -D CMAKE_CXX_COMPILER=clang++ "-DLLVM_DIR=C:/llvm/lib/cmake/llvm"
-          cmake --build build --config Release
+          cmake -G Ninja -B build -D CMAKE_BUILD_TYPE=Debug -D CMAKE_C_COMPILER=clang -D CMAKE_CXX_COMPILER=clang++ "-DLLVM_DIR=C:/llvm/lib/cmake/llvm"
+          cmake --build build --config Debug
           cpack --config build/CPackConfig.cmake
         shell: cmd
 

--- a/.github/workflows/push-run-actions.yml
+++ b/.github/workflows/push-run-actions.yml
@@ -62,6 +62,7 @@ jobs:
         run: |
           cmake -G Ninja -B build -D CMAKE_BUILD_TYPE=Release -D CMAKE_C_COMPILER=clang -D CMAKE_CXX_COMPILER=clang++
           cmake --build build --config Release
+          cpack --config build/CPackConfig.cmake
         shell: bash
 
       - name: Build Package on macOS
@@ -69,6 +70,7 @@ jobs:
         run: |
           cmake -G Ninja -B build -D CMAKE_BUILD_TYPE=Release -D CMAKE_C_COMPILER=clang -D CMAKE_CXX_COMPILER=clang++ "-DLLVM_DIR=$(brew --prefix llvm)/lib/cmake/llvm"
           cmake --build build --config Release
+          cpack --config build/CPackConfig.cmake
         shell: bash
 
       - name: Build Package on Windows
@@ -76,4 +78,23 @@ jobs:
         run: |
           cmake -G Ninja -B build -D CMAKE_BUILD_TYPE=Release -D CMAKE_C_COMPILER=clang -D CMAKE_CXX_COMPILER=clang++ "-DLLVM_DIR=C:/llvm/lib/cmake/llvm"
           cmake --build build --config Release
+          cpack --config build/CPackConfig.cmake
         shell: cmd
+
+      - name: Upload artifacts
+        if: runner.os == 'macOS'
+        uses: actions/upload-artifact@v4
+        with:
+          path: lldb-frontend-darwin.tar.gz
+
+      - name: Upload artifacts
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v4
+        with:
+          path: lldb-frontend-windows.tar.gz
+
+      - name: Upload artifacts
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v4
+        with:
+          path: lldb-frontend-linux.tar.gz

--- a/.github/workflows/push-run-actions.yml
+++ b/.github/workflows/push-run-actions.yml
@@ -85,16 +85,19 @@ jobs:
         if: runner.os == 'macOS'
         uses: actions/upload-artifact@v4
         with:
+          name: lldb-frontend-darwin
           path: lldb-frontend-darwin.tar.gz
 
       - name: Upload artifacts
         if: runner.os == 'Windows'
         uses: actions/upload-artifact@v4
         with:
+          name: lldb-frontend-windows
           path: lldb-frontend-windows.tar.gz
 
       - name: Upload artifacts
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@v4
         with:
+          name: lldb-frontend-linux
           path: lldb-frontend-linux.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ build/
 .cache/
 .DS_Store
 build-windows/
+_CPack_Packages
+*.tar.gz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,12 @@
 cmake_minimum_required(VERSION 3.20)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+set(FETCHCONTENT_QUIET OFF)
 include(FetchContent)
 
-# ================================================
-#     Setup project
-# ================================================
-project(lldb-frontend LANGUAGES C CXX)
+include(cmake/Version.cmake)
+project(lldb-frontend LANGUAGES C CXX VERSION ${LDBF_V_MAJ}.${LDBF_V_MIN}.${LDBF_V_PAT}.${LDBF_V_TWE})
 
-# ================================================
-#     Setup libraries with FetchContent
-# ================================================
 FetchContent_Declare(glfw GIT_REPOSITORY https://github.com/glfw/glfw.git)
 FetchContent_MakeAvailable(glfw)
 
@@ -27,10 +24,6 @@ add_library(tfd  libs/tfd/tinyfiledialogs.c)
 
 include(cmake/LLVM.cmake)
 
-
-# ================================================
-#     Setup main lldb-frontend executable and linker data
-# ================================================
 set(SOURCES 
   src/main.cpp 
   src/Window.cpp 
@@ -44,10 +37,13 @@ set(SOURCES
 
 add_executable(lldb-frontend ${SOURCES})
 target_compile_features(lldb-frontend PRIVATE cxx_std_23)
-
 target_link_libraries(lldb-frontend PRIVATE glfw glad imgui tfd LLDB::liblldb)
 target_link_directories(lldb-frontend PRIVATE ${LLVM_LIB_DIR})
 target_include_directories(lldb-frontend PRIVATE ${LLVM_INCLUDE_DIR} ${CMAKE_SOURCE_DIR}/libs/glad/include ${CMAKE_SOURCE_DIR}/libs/tfd)
+
+install(TARGETS lldb-frontend
+  RUNTIME DESTINATION bin COMPONENT Runtime)
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/resources/ DESTINATION share/lldb-frontend COMPONENT Runtime FILES_MATCHING PATTERN "*.ini")
 
 set(TEST_SOURCES
   test/test.cpp
@@ -55,4 +51,32 @@ set(TEST_SOURCES
 
 add_executable(lldb-frontend-test ${TEST_SOURCES})
 target_compile_features(lldb-frontend-test PRIVATE cxx_std_23)
+
+install(TARGETS lldb-frontend-test
+  RUNTIME DESTINATION bin COMPONENT Tests)
+
+# install(FILES ${CMAKE_SOURCE_DIR}/LICENSE DESTINATION share/doc COMPONENT Runtime OPTIONAL)
+
+set(CPACK_PACKAGE_NAME "lldb-frontend")
+set(CPACK_PACKAGE_VENDOR "lldb-frontend Contributors")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "LLDB Frontend UI")
+set(CPACK_PACKAGE_VERSION_MAJOR ${LDBF_V_MAJ})
+set(CPACK_PACKAGE_VERSION_MINOR ${LDBF_V_MIN})
+set(CPACK_PACKAGE_VERSION_PATCH ${LDBF_V_PAT})
+set(CPACK_PACKAGE_VERSION_TWEAK ${LDBF_V_TWE})
+# set(CPACK_RESOURCE_FILE_LICENSE ${CMAKE_SOURCE_DIR}/LICENSE)
+set(CPACK_RESOURCE_FILE_README ${CMAKE_SOURCE_DIR}/README.md)
+set(CPACK_PACKAGE_CONTACT "rfmineguy@gmail.com")
+set(CPACK_GENERATOR "TGZ")
+
+set(CPACK_COMPONENTS_ALL Runtime Tests)
+set(CPACK_COMPONENT_RUNTIME_DISPLAY_NAME "LLDB Frontend Runtime")
+set(CPACK_COMPONENT_TESTS_DISPLAY_NAME "LLDB Frontend Tests")
+set(CPACK_COMPONENT_RUNTIME_DESCRIPTION "The core executable and resources for lldb-frontend")
+set(CPACK_COMPONENT_TESTS_DESCRIPTION "Unit tests for lldb-frontend")
+string(TOLOWER "${CMAKE_SYSTEM_NAME}" SYSTEM_NAME_LOWER)
+set(CPACK_PACKAGE_FILE_NAME "lldb-frontend-${SYSTEM_NAME_LOWER}")
+
+include(CPack)
+
 file(COPY imgui.ini DESTINATION ${CMAKE_BINARY_DIR})

--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -1,0 +1,4 @@
+set(LDBF_V_MAJ 1)
+set(LDBF_V_MIN 0)
+set(LDBF_V_PAT 0)
+set(LDBF_V_TWE 0)


### PR DESCRIPTION
This PR implements the required CMake `install()` directives, as well as `CPack` configuration such that you can now run `cpack --config build/CPackConfig.cmake` to get a generated `.tar.gz` with `lldb-frontend` binaries.

Also in `push-run-actions.yml`, uploading a OS built `.tar.gz` artifact is correctly working.

Also, all builds in the workflow are now Debug builds