### PR TITLE
Lldb target running

### DIFF
--- a/src/ImGuiLayer.cpp
+++ b/src/ImGuiLayer.cpp
@@ -168,6 +168,7 @@ void ImGuiLayer::DrawDebugWindow() {
 
     auto& dctx = window_ref->GetDebuggerCtx();
 
+    Logger::Info("TargetPath: {}", target_path);
     dctx.SetTarget(dctx.GetDebugger().CreateTarget(target_path.c_str()));
 
     auto target = dctx.GetTarget();
@@ -187,6 +188,8 @@ void ImGuiLayer::DrawDebugWindow() {
 
     Util::PrintTargetModules(target);
     Util::PrintModuleCompileUnits(target, 0);
+
+    dctx.LaunchTarget();
   }
   ImGui::End();
 }

--- a/src/LLDBDebugger.cpp
+++ b/src/LLDBDebugger.cpp
@@ -39,6 +39,8 @@ void LLDBDebugger::LaunchTarget() {
   Logger::Info("Launch Status: {}", error.Success() ? "Success" : "Fail");
   Logger::Info("Is process valid? {}", process.IsValid() ? "Yes" : "No");
 
+  // If the event thread has been run before, join it so we can spawn it again
+  if (lldbEventThread.joinable()) lldbEventThread.join();
   lldbEventThread = std::thread([&]() {
     LLDBEventThread();
   });

--- a/src/LLDBDebugger.hpp
+++ b/src/LLDBDebugger.hpp
@@ -2,6 +2,7 @@
 #define LLDB_DEBUGGER_HPP
 #include <lldb/API/LLDB.h>
 #include <string>
+#include <thread>
 
 struct FileContext;
 
@@ -19,6 +20,7 @@ class LLDBDebugger {
     LLDBDebugger();
     ~LLDBDebugger();
 
+    void LaunchTarget();
     lldb::SBDebugger& GetDebugger(); 
     lldb::SBTarget GetTarget();
     void SetTarget(lldb::SBTarget target);
@@ -31,9 +33,15 @@ class LLDBDebugger {
     ExecResult ExecCommand(const std::string&);
 
   private:
+    void LLDBEventThread();
+
+  private:
     lldb::SBDebugger debugger;
     std::unordered_map<lldb::break_id_t, BreakpointData> id_breakpoint_data;
 
+    lldb::SBTarget target;
+    lldb::SBListener listener;
+    std::thread lldbEventThread;
 };
 
 #endif

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -14,13 +14,13 @@ Logger::ScopedGroup::~ScopedGroup() {
 
 
 void Logger::BeginGroup(const std::string & tag) {
-  Println("{}[{}]\n", std::string(log_depth * LOG_SPACING, ' '), tag);
+  Println("{}[{}]", std::string(log_depth * LOG_SPACING, ' '), tag);
   groupStack.push(tag);
   log_depth++;
 }
 void Logger::EndGroup() {
   log_depth--;
-  Println("{}[{}]\n", std::string(log_depth * LOG_SPACING, ' '), groupStack.top());
+  Println("{}[{}]", std::string(log_depth * LOG_SPACING, ' '), groupStack.top());
   groupStack.pop();
 }
 void Logger::BeginLine(const std::string& tag) {

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -2,4 +2,12 @@
 
 int main() {
   std::cout << "Hello world from test" << std::endl;
+  std::cout << "Hello world from test" << std::endl;
+  std::cout << "Hello world from test" << std::endl;
+
+  int x = 4;
+  while (x > 0) {
+    std::cout << "x: " << x << std::endl;
+    x--;
+  }
 }


### PR DESCRIPTION
This PR based on #17 sets up a way to `LaunchTarget()`s and have the executable run as an embedded process.
It utilizes the target creation methods added in #17 as well.

- [x] Redirects the output of that running process to the output of `lldb-frontend` so we can see the program running.
- [x] Sets up a very basic and barebones threaded lldb event loop whose lifetime is managed by lldb events.
   - Event to note is the `eStateExited` event as this is the event that allows the thread to shutdown
- [x] Noticed that the output of logger groups seemed wrong. `GroupBegin()` calls intentionally have no newline at the end.

> [!NOTE]
> This is not integrated into the code view UI yet.