### PR TITLE
Breakpoints reorganized

### DIFF
--- a/src/FileHeirarchy.cpp
+++ b/src/FileHeirarchy.cpp
@@ -1,8 +1,9 @@
 #include "FileHeirarchy.hpp"
 #include "Logger.hpp"
 #include <iostream>
+#include <fstream>
 
-
+// HeirarchyElement
 FileHeirarchy::HeirarchyElement::HeirarchyElement(
     const std::string& local_path,
     const std::string& full_path,
@@ -14,6 +15,25 @@ FileHeirarchy::HeirarchyElement::HeirarchyElement(
   type(type),
   c_str(full_path_string.c_str()) {}
 
+bool FileHeirarchy::HeirarchyElement::LoadFromDisk() {
+  Logger::ScopedGroup g("HeirarchyElement::LoadFromDisk");
+  if (lines->empty()) {
+    std::ifstream f(full_path);
+    if (!f.is_open()) {
+      Logger::Crit("Failed to load {} from disk", full_path.string());
+      return false;
+    }
+    std::string line;
+    while (std::getline(f, line)) {
+      lines->push_back({.line = line, .bp = false});
+    }
+    f.close();
+    Logger::Info("Loaded {} from disk", full_path.string());
+  }
+  return true;
+}
+
+// FileHeirarchy
 FileHeirarchy::FileHeirarchy(): mainRoot(new HeirarchyElement("/", "/")) {}
 FileHeirarchy::~FileHeirarchy() {
   Free(mainRoot);

--- a/src/FileHeirarchy.hpp
+++ b/src/FileHeirarchy.hpp
@@ -3,6 +3,9 @@
 #include <map>
 #include <string>
 #include <filesystem>
+#include <optional>
+#include <vector>
+#include "FileContext.hpp"
 
 class FileHeirarchy {
   public:
@@ -18,11 +21,16 @@ class FileHeirarchy {
 
       std::map<std::string, HeirarchyElement*> children;
 
+      std::optional<std::vector<Line>> lines;
+
       HeirarchyElement(
           const std::string& local_path,
           const std::string& full_path,
           HeirarchyElementType type = HeirarchyElementType::FOLDER
       );
+
+      public:
+        bool LoadFromDisk();
     };
   public:
     FileHeirarchy();

--- a/src/ImGuiCustomWidgets.cpp
+++ b/src/ImGuiCustomWidgets.cpp
@@ -5,7 +5,8 @@
 #include <imgui.h>
 
 namespace ImGuiCustom {
-  void Breakpoint(int id, Line& line, FileContext& fctx, ImGuiLayer& imguiLayer) {
+  void Breakpoint(int id, FileHeirarchy::HeirarchyElement& element, ImGuiLayer& imguiLayer) {
+    if (element.lines->empty()) return;
     ImVec2 cursorPos = ImGui::GetCursorScreenPos();
     float radius = 6.0f;
     float diameter = radius * 2.0f;
@@ -15,9 +16,9 @@ namespace ImGuiCustom {
     if (ImGui::IsItemClicked())
     {
       auto& debugger = imguiLayer.GetDebugger();
-      auto actioned = (!line.bp) ?
-        debugger.AddBreakpoint(fctx, id) :
-        debugger.RemoveBreakpoint(fctx, id);
+      auto actioned = (!element.lines->at(id).bp) ?
+        debugger.AddBreakpoint(element, id) :
+        debugger.RemoveBreakpoint(element, id);
     }
 
     // Get draw list and draw circle
@@ -28,7 +29,7 @@ namespace ImGuiCustom {
     drawList->AddCircle(center, radius, IM_COL32(255, 255, 255, 255), 16, 1.5f);
 
     // If checked, draw filled circle
-    if (line.bp) {
+    if (element.lines->at(id).bp) {
       drawList->AddCircleFilled(center, radius - 2.0f, IM_COL32(255, 255, 255, 255), 16);
     }
   }

--- a/src/ImGuiCustomWidgets.hpp
+++ b/src/ImGuiCustomWidgets.hpp
@@ -1,12 +1,13 @@
 #ifndef CUSTOM_IMGUI_WIDGETS_HPP
 #define CUSTOM_IMGUI_WIDGETS_HPP
+#include "FileHeirarchy.hpp"
 
 struct Line;
 struct FileContext;
 struct ImGuiLayer;
 
 namespace ImGuiCustom {
-  void Breakpoint(int id, Line& line, FileContext& fctx, ImGuiLayer& imguiLayer);
+  void Breakpoint(int id, FileHeirarchy::HeirarchyElement& element, ImGuiLayer& imguiLayer);
 }
 
 #endif

--- a/src/ImGuiLayer.cpp
+++ b/src/ImGuiLayer.cpp
@@ -191,11 +191,12 @@ void ImGuiLayer::DrawDebugWindow() {
   ImGui::End();
 }
 
-void ImGuiLayer::DrawCodeFile(FileContext& fctx) {
-  for (int i = 0; i < fctx.lines.size(); i++) {
-    auto& line = fctx.lines.at(i);
+void ImGuiLayer::DrawCodeFile(FileHeirarchy::HeirarchyElement& element) {
+  if (element.lines->empty()) return;
+  for (int i = 0; i < element.lines->size(); i++) {
+    auto& line = element.lines->at(i);
     ImGui::PushID(i);
-    ImGuiCustom::Breakpoint(i, line, fctx, *this); ImGui::SameLine();
+    ImGuiCustom::Breakpoint(i, element, *this); ImGui::SameLine();
     ImVec2 cursor = ImGui::GetCursorScreenPos();
     ImVec2 text_size = ImGui::CalcTextSize(line.line.c_str());
     ImVec2 line_size = ImVec2(ImGui::GetWindowWidth() - ImGui::GetStyle().WindowPadding.x * 1.75, text_size.y * 1.5);
@@ -217,7 +218,7 @@ void ImGuiLayer::DrawCodeWindow() {
       auto local_path_string = file->local_path.string();
       auto full_path_string = file->full_path.string();
       if (ImGui::BeginTabItem(local_path_string.c_str())) {
-        DrawCodeFile(fileContentsMap.at(full_path_string));
+        DrawCodeFile(*file);
         ImGui::EndTabItem();
       }
     }
@@ -240,7 +241,7 @@ void ImGuiLayer::DrawControlsWindow() {
   ImGui::End();
 }
 
-bool ImGuiLayer::ShowHeirarchyItem(const FileHeirarchy::HeirarchyElement* element) {
+bool ImGuiLayer::ShowHeirarchyItem(FileHeirarchy::HeirarchyElement* element) {
   bool isLeaf = element->children.empty();
 
   ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_None;
@@ -250,6 +251,7 @@ bool ImGuiLayer::ShowHeirarchyItem(const FileHeirarchy::HeirarchyElement* elemen
   if (isLeaf && ImGui::IsItemClicked(0)) {
     auto element_full_path_string = element->full_path.string();
     Logger::Info("Clicked {}", element_full_path_string);
+    element->LoadFromDisk();
     if (LoadFile(element_full_path_string)) {
       if (std::find(openFiles.begin(), openFiles.end(), element) == openFiles.end()) {
         openFiles.push_back((FileHeirarchy::HeirarchyElement*)element);
@@ -263,7 +265,7 @@ bool ImGuiLayer::ShowHeirarchyItem(const FileHeirarchy::HeirarchyElement* elemen
   return opened;
 }
 
-void ImGuiLayer::FileHeirarchyRecursive(const FileHeirarchy::HeirarchyElement* element) {
+void ImGuiLayer::FileHeirarchyRecursive(FileHeirarchy::HeirarchyElement* element) {
   if (element == nullptr) return;
   if (ShowHeirarchyItem(element)) {
     for (auto& [key, child] : element->children) {

--- a/src/ImGuiLayer.hpp
+++ b/src/ImGuiLayer.hpp
@@ -31,12 +31,12 @@ class ImGuiLayer {
     void DrawBreakpointsWindow();
     void DrawLLDBCommandWindow();
 
-    bool ShowHeirarchyItem(const FileHeirarchy::HeirarchyElement*);
-    void FileHeirarchyRecursive(const FileHeirarchy::HeirarchyElement*);
+    bool ShowHeirarchyItem(FileHeirarchy::HeirarchyElement*);
+    void FileHeirarchyRecursive(FileHeirarchy::HeirarchyElement*);
     void DrawFileBrowser();
 
   private:
-    void DrawCodeFile(FileContext&);
+    void DrawCodeFile(FileHeirarchy::HeirarchyElement&);
 
   private:
     static int TextEditCallbackStub(ImGuiInputTextCallbackData* data);

--- a/src/LLDBDebugger.hpp
+++ b/src/LLDBDebugger.hpp
@@ -23,8 +23,8 @@ class LLDBDebugger {
     lldb::SBTarget GetTarget();
     void SetTarget(lldb::SBTarget target);
 
-    bool AddBreakpoint(FileContext& fctx, int id);
-    bool RemoveBreakpoint(FileContext& fctx, int id);
+    bool AddBreakpoint(FileHeirarchy::HeirarchyElement&, int id);
+    bool RemoveBreakpoint(FileHeirarchy::HeirarchyElement&, int id);
     BreakpointData& GetBreakpointData(lldb::break_id_t id);
 
   public:


### PR DESCRIPTION
This PR moves the storage of the Line information (i.e. breakpoints and text) into the file heirarchy structure.

I think this will make accessing breakpoint information in the ImGui structure a bit easier, and provides an interface through the FileHeirarchy.