### PR TITLE
[PR] Lldb command window

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,8 @@ endif ()
 
 set(TEST_SOURCES
   test/test.cpp
-  test/test_support.cpp)
+  test/test_support.cpp
+  test/nested/nested.cpp)
 
 add_executable(${PROJECT_NAME}-test ${TEST_SOURCES})
 target_compile_features(${PROJECT_NAME}-test PRIVATE cxx_std_23)

--- a/src/FileHeirarchy.cpp
+++ b/src/FileHeirarchy.cpp
@@ -38,6 +38,10 @@ FileHeirarchy::FileHeirarchy(): mainRoot(new HeirarchyElement("/", "/")) {}
 FileHeirarchy::~FileHeirarchy() {
   Free(mainRoot);
 }
+void FileHeirarchy::SetWorkingDir(const std::string& workingdir) {
+  Free(mainRoot);
+  mainRoot = new HeirarchyElement(workingdir, workingdir);
+}
 
 void FileHeirarchy::Free(HeirarchyElement* element) {
   for (auto& [key, child] : element->children) {
@@ -49,14 +53,15 @@ void FileHeirarchy::Free(HeirarchyElement* element) {
 void FileHeirarchy::AddFile(const std::string& dir, const std::string& filename) {
   FileHeirarchy::HeirarchyElement* current = mainRoot;
   auto full_path = std::filesystem::path(dir) / filename;
+  auto relative_path = std::filesystem::relative(full_path, mainRoot->full_path);
 
-  auto it = full_path.begin();
-  for (; it != full_path.end(); ++it) {
+  auto it = relative_path.begin();
+  for (; it != relative_path.end(); ++it) {
       std::string part = it->string();
       if (part.empty() || part == "/") continue;
 
       // Last part is file
-      bool is_last = std::next(it) == full_path.end();
+      bool is_last = std::next(it) == relative_path.end();
       bool is_file = is_last; // assume file if it's the end
 
       auto& children = current->children;

--- a/src/FileHeirarchy.cpp
+++ b/src/FileHeirarchy.cpp
@@ -98,3 +98,17 @@ void FileHeirarchy::Print() const {
 FileHeirarchy::HeirarchyElement* FileHeirarchy::GetRoot() const {
   return mainRoot;
 }
+
+FileHeirarchy::HeirarchyElement* FileHeirarchy::GetElementByLocalPath(const std::string& localpath) {
+  return GetElementByLocalPathRec(mainRoot, localpath);
+}
+
+FileHeirarchy::HeirarchyElement* FileHeirarchy::GetElementByLocalPathRec(FileHeirarchy::HeirarchyElement* root, const std::string& localpath) const {
+  if (!root) return nullptr;
+  if (root->local_path == localpath) return root;
+  for (auto& [key, child] : root->children) {
+    auto elem = GetElementByLocalPathRec(child, localpath);
+    if (elem) return elem;
+  }
+  return nullptr;
+}

--- a/src/FileHeirarchy.hpp
+++ b/src/FileHeirarchy.hpp
@@ -38,9 +38,11 @@ class FileHeirarchy {
     void AddFile(const std::string& dir, const std::string& filename);
     void Print() const;
     HeirarchyElement* GetRoot() const;
+    HeirarchyElement* GetElementByLocalPath(const std::string& localpath);
 
   private:
     void Free(HeirarchyElement* root);
+    HeirarchyElement* GetElementByLocalPathRec(HeirarchyElement* root, const std::string& localpath) const;
     void PrintRec(const HeirarchyElement* root, int depth = 0) const;
 
   private:

--- a/src/FileHeirarchy.hpp
+++ b/src/FileHeirarchy.hpp
@@ -16,6 +16,7 @@ class FileHeirarchy {
       HeirarchyElementType type;
       std::filesystem::path local_path;
       std::filesystem::path full_path;
+      std::filesystem::path relative_path;
       std::string full_path_string;
       const char* c_str;
 
@@ -35,6 +36,7 @@ class FileHeirarchy {
   public:
     FileHeirarchy();
     ~FileHeirarchy();
+    void SetWorkingDir(const std::string& workingdir);
     void AddFile(const std::string& dir, const std::string& filename);
     void Print() const;
     HeirarchyElement* GetRoot() const;

--- a/src/ImGuiLayer.cpp
+++ b/src/ImGuiLayer.cpp
@@ -127,6 +127,7 @@ void ImGuiLayer::DrawDebugWindow() {
   // Open File Dialog
   if (ImGui::Button("Open File Dialog")) {
     const char* fdpath = tinyfd_openFileDialog("Choose File", "", 0, NULL, "executables", 0);
+    std::filesystem::path path(fdpath);
     if (fdpath) {
       Logger::ScopedGroup g("OpenFileDialog");
       Logger::Info("Path: {}", fdpath);
@@ -138,6 +139,10 @@ void ImGuiLayer::DrawDebugWindow() {
         .CreateTarget(fdpath));
 
       auto target = dctx.GetTarget();
+      auto working_dir = Util::GetTargetSourceRootDirectory(path)->string();
+      Logger::Info("Working Dir: {}", working_dir);
+
+      fh.SetWorkingDir(working_dir);
 
       for (size_t i = 0; i < target.GetNumModules(); i++) {
         lldb::SBModule mod = target.GetModuleAtIndex(i);
@@ -172,6 +177,10 @@ void ImGuiLayer::DrawDebugWindow() {
     dctx.SetTarget(dctx.GetDebugger().CreateTarget(target_path.c_str()));
 
     auto target = dctx.GetTarget();
+    auto working_dir = Util::GetTargetSourceRootDirectory(target_path)->string();
+    Logger::Info("Working Dir: {}", working_dir);
+
+    fh.SetWorkingDir(working_dir);
 
     for (size_t i = 0; i < target.GetNumModules(); i++) {
       lldb::SBModule mod = target.GetModuleAtIndex(i);

--- a/src/ImGuiLayer.cpp
+++ b/src/ImGuiLayer.cpp
@@ -335,13 +335,13 @@ void ImGuiLayer::DrawLLDBCommandWindow() {
   if (ImGui::InputText("Input", inputBuf, IM_ARRAYSIZE(inputBuf), input_text_flags, &TextEditCallbackStub, (void*)this))
   {
       items.push_back(std::string(inputBuf));
-      auto result = window_ref->GetDebuggerCtx().ExecCommand(inputBuf);
-      switch (result) {
-        case LLDBDebugger::ExecResult::Ok:
-          Logger::Todo("ExecResult::Ok unimplemented");
+      auto result = window_ref->GetDebuggerCtx().ExecCommand(inputBuf, fh);
+      switch (result.status) {
+        case LLDBDebugger::ExecResultStatus::Ok:
+          Logger::Todo("ExecResult::Ok");
           break;
         default:
-          Logger::Crit("ExecCommand failed {}", (int)result);
+          Logger::Crit("ExecResult::Fail => {}", result.message);
       }
       reclaim_focus = true;
   }

--- a/src/Includes.cpp
+++ b/src/Includes.cpp
@@ -44,4 +44,5 @@
 #include "LLDBDebugger.hpp"
 #include "Logger.hpp"
 #include "Util.hpp"
+#include "LLDBCommandParser.hpp"
 #include "Window.hpp"

--- a/src/LLDBCommandParser.cpp
+++ b/src/LLDBCommandParser.cpp
@@ -7,6 +7,44 @@ LLDB_CommandParser::LLDB_CommandParser() {}
 LLDB_CommandParser::~LLDB_CommandParser() {}
 
 LLDB_CommandParser::ParsedCommand LLDB_CommandParser::Parse(const std::string& command) {
+  std::vector<std::string> split = SplitBySpaces(command);
+  if (split.size() == 0) return LLDB_CommandParser::ParsedCommand{.type = ParsedCommandType::EMPTY};
+
+  // Parse short form first
+  //  b main.cpp:3
+  if (split.at(0) == "b") {
+    if (split.size() == 1) return LLDB_CommandParser::Invalid("Incomplete breakpoint command");
+    auto& where = split.at(1);
+    size_t colon = where.find(":");
+    if (colon != std::string::npos) { // b <file>:<line>
+      std::string file = where.substr(0, colon);
+      std::string line = where.substr(colon + 1);
+      try {
+        int line_int = std::stoi(std::string(line));
+        return ParsedCommand{.type = ParsedCommandType::BREAKPOINT_FILE_LINE, .command = BPFileLine(file, line_int)};
+      } catch (std::invalid_argument e) {
+        return LLDB_CommandParser::Invalid("Breakpoint line '{}' not an integer", line);
+      } catch (std::out_of_range e) {
+        return LLDB_CommandParser::Invalid("Breakpoint line '{}' out of range", line);
+      }
+    }
+    else { // b <symbol>
+      return ParsedCommand{.type = ParsedCommandType::BREAKPOINT_SYMBOL, .command = BPSymbol(where)};
+    }
+  }
+  if (split.size() == 1 && split.at(0) == "n") {
+    return ParsedCommand{.type = ParsedCommandType::NEXT};
+  }
+  if (split.size() == 1 && split.at(0) == "s") {
+    return ParsedCommand{.type = ParsedCommandType::STEP};
+  }
+  if (split.size() == 1 && split.at(0) == "c") {
+    return ParsedCommand{.type = ParsedCommandType::CONTINUE};
+  }
+  if (split.size() == 1 && split.at(0) == "r") {
+    return ParsedCommand{.type = ParsedCommandType::RUN};
+  }
+  return LLDB_CommandParser::Invalid("{} not valid", command);
 }
 
 std::vector<std::string> LLDB_CommandParser::SplitBySpaces(const std::string& s) {

--- a/src/LLDBCommandParser.cpp
+++ b/src/LLDBCommandParser.cpp
@@ -21,7 +21,7 @@ LLDB_CommandParser::ParsedCommand LLDB_CommandParser::Parse(const std::string& c
       std::string line = where.substr(colon + 1);
       try {
         int line_int = std::stoi(std::string(line));
-        return ParsedCommand{.type = ParsedCommandType::BREAKPOINT_FILE_LINE, .command = BPFileLine(file, line_int)};
+        return ParsedCommand{.type = ParsedCommandType::BREAKPOINT_FILE_LINE, .command = BPFileLine{file, line_int}};
       } catch (std::invalid_argument e) {
         return LLDB_CommandParser::Invalid("Breakpoint line '{}' not an integer", line);
       } catch (std::out_of_range e) {
@@ -29,7 +29,7 @@ LLDB_CommandParser::ParsedCommand LLDB_CommandParser::Parse(const std::string& c
       }
     }
     else { // b <symbol>
-      return ParsedCommand{.type = ParsedCommandType::BREAKPOINT_SYMBOL, .command = BPSymbol(where)};
+      return ParsedCommand{.type = ParsedCommandType::BREAKPOINT_SYMBOL, .command = BPSymbol{where}};
     }
   }
   if (split.size() == 1 && split.at(0) == "n") {

--- a/src/LLDBCommandParser.cpp
+++ b/src/LLDBCommandParser.cpp
@@ -10,4 +10,13 @@ LLDB_CommandParser::ParsedCommand LLDB_CommandParser::Parse(const std::string& c
 }
 
 std::vector<std::string> LLDB_CommandParser::SplitBySpaces(const std::string& s) {
+    std::vector<std::string> tokens;
+    std::istringstream iss(s); // Create an input string stream from the string
+    std::string token;
+
+    // Extract tokens until the end of the stream
+    while (iss >> token) {
+        tokens.push_back(token);
+    }
+    return tokens;
 }

--- a/src/LLDBCommandParser.cpp
+++ b/src/LLDBCommandParser.cpp
@@ -1,0 +1,13 @@
+#include "LLDBCommandParser.hpp"
+#include "Logger.hpp"
+#include <sstream>
+#include <string> 
+
+LLDB_CommandParser::LLDB_CommandParser() {}
+LLDB_CommandParser::~LLDB_CommandParser() {}
+
+LLDB_CommandParser::ParsedCommand LLDB_CommandParser::Parse(const std::string& command) {
+}
+
+std::vector<std::string> LLDB_CommandParser::SplitBySpaces(const std::string& s) {
+}

--- a/src/LLDBCommandParser.hpp
+++ b/src/LLDBCommandParser.hpp
@@ -1,0 +1,51 @@
+#ifndef LLDB_COMMAND_PARSER_HPP
+#define LLDB_COMMAND_PARSER_HPP
+#include <string_view>
+#include <vector>
+#include <variant>
+#include <fmt/core.h>
+
+class LLDB_CommandParser {
+public:
+  enum class ParsedCommandType : int {
+    EMPTY = 0, INVALID,
+    BREAKPOINT_FILE_LINE, BREAKPOINT_SYMBOL,
+    RUN, CONTINUE, STEP, NEXT,
+  };
+  struct InvalidCmd {
+    std::string message;
+  };
+  struct BPFileLine {
+    std::string file;
+    int line;
+  };
+  struct BPSymbol {
+    std::string symbol;
+  };
+  struct ParsedCommand {
+    ParsedCommandType type;
+    std::variant<
+      std::monostate,
+      InvalidCmd,
+      BPFileLine,
+      BPSymbol
+    > command;
+  };
+public:
+  LLDB_CommandParser();
+  ~LLDB_CommandParser();
+  ParsedCommand Parse(const std::string& command);
+
+protected:
+  template <typename ...Args>
+  static ParsedCommand Invalid(std::string_view fmt, Args&&... args) {
+    return ParsedCommand{.type = ParsedCommandType::INVALID,
+      .command = InvalidCmd(fmt::vformat(fmt, fmt::make_format_args(std::forward<Args>(args)...)))
+    };
+  }
+
+private:
+  std::vector<std::string> SplitBySpaces(const std::string& s);
+};
+
+#endif

--- a/src/LLDBCommandParser.hpp
+++ b/src/LLDBCommandParser.hpp
@@ -40,7 +40,7 @@ protected:
   template <typename ...Args>
   static ParsedCommand Invalid(std::string_view fmt, Args&&... args) {
     return ParsedCommand{.type = ParsedCommandType::INVALID,
-      .command = InvalidCmd(fmt::vformat(fmt, fmt::make_format_args(std::forward<Args>(args)...)))
+      .command = InvalidCmd{.message=fmt::vformat(fmt, fmt::make_format_args(std::forward<Args>(args)...))}
     };
   }
 

--- a/src/LLDBDebugger.cpp
+++ b/src/LLDBDebugger.cpp
@@ -81,7 +81,12 @@ void LLDBDebugger::SetTarget(lldb::SBTarget target) {
 }
 
 bool LLDBDebugger::AddBreakpoint(FileHeirarchy::HeirarchyElement& element, int id) {
-  if (element.lines->empty()) return false;
+  if (element.lines->empty()) {
+    // If we try to add a breakpoint and the file hasnt been loaded yet, we have to load it
+    //   so that we have access to its lines
+    // There might be a better way to do this, but for now this works fine.
+    element.LoadFromDisk();
+  }
 
     if (id < 0 || id >= static_cast<int>(element.lines->size())) {
         return false;
@@ -103,6 +108,7 @@ bool LLDBDebugger::AddBreakpoint(FileHeirarchy::HeirarchyElement& element, int i
         line.bp_id = bp.GetID();
         auto real_filename = element.full_path.string();
         id_breakpoint_data[line.bp_id] = {real_filename, line_number};
+        Logger::Info("Set breakpoint at {} on line {}", filename, line_number);
         return true;
     }
 

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -65,4 +65,33 @@ namespace Util {
 
     return exePath.parent_path();
   }
+
+
+  static std::vector<std::string> projectRootMarkers = {
+    "CMakeLists.txt",
+    "Makefile",
+    "build.zig",
+    "meson.build",
+    "Cargo.toml",
+    "package.json",
+    "pyproject.toml",
+    ".git"
+  };
+
+  std::optional<std::filesystem::path> GetTargetSourceRootDirectory(std::filesystem::path start_dir) {
+    using namespace std::filesystem;
+    path current = start_dir;
+    while (!current.empty()) {
+      Logger::Info("Current: {}", current.string());
+      for (const auto& marker : projectRootMarkers) {
+        if (std::filesystem::exists(current / marker)) {
+          Logger::Info("Has marker '{}': {}", marker, current.string());
+          return current;
+        }
+      }
+      current = current.parent_path();
+    }
+    return std::nullopt;
+  }
 }
+

--- a/src/Util.hpp
+++ b/src/Util.hpp
@@ -2,11 +2,13 @@
 #define UTIL_HPP
 #include <lldb/API/LLDB.h>
 #include <filesystem>
+#include <optional>
 
 namespace Util {
   void PrintTargetModules(lldb::SBTarget& target);
   void PrintModuleCompileUnits(lldb::SBTarget& target, int moduleIdx);
   std::filesystem::path GetCurrentProgramDirectory();
+  std::optional<std::filesystem::path> GetTargetSourceRootDirectory(std::filesystem::path start_dir);
 }
 
 #endif

--- a/src/lldb-frontend.cpp
+++ b/src/lldb-frontend.cpp
@@ -8,6 +8,7 @@
 #include "Util.cpp"
 #include "Logger.cpp"
 #include "Args.cpp"
+#include "LLDBCommandParser.cpp"
 #include "main.cpp"
 #include "ImGuiCustomWidgets.hpp"
 #include "ImGuiLayer.hpp"

--- a/test/nested/nested.cpp
+++ b/test/nested/nested.cpp
@@ -1,0 +1,10 @@
+#include "nested.hpp"
+#include <iostream>
+
+Nested::Nested() {
+  std::cout << "Nested constructed" << std::endl;
+}
+
+Nested::~Nested() {
+  std::cout << "Nested destructed" << std::endl;
+}

--- a/test/nested/nested.hpp
+++ b/test/nested/nested.hpp
@@ -1,0 +1,10 @@
+#ifndef NESTED_HPP
+#define NESTED_HPP
+
+class Nested {
+  public:
+    Nested();
+    ~Nested();
+};
+
+#endif

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include "nested/nested.hpp"
 
 void testFunction() {
   std::cout << "testFunction()" << std::endl;
@@ -14,4 +15,6 @@ int main() {
     std::cout << "x: " << x << std::endl;
     x--;
   }
+
+  Nested n;
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,5 +1,9 @@
 #include <iostream>
 
+void testFunction() {
+  std::cout << "testFunction()" << std::endl;
+}
+
 int main() {
   std::cout << "Hello world from test" << std::endl;
   std::cout << "Hello world from test" << std::endl;


### PR DESCRIPTION
LLDB Command Parser
- [x] Breakpoints
     - [x] Symbol          `b main`
     - [x] File:Line         `b test.cpp:4`
- [x] Step                    `s`
- [x] Next                    `n`
- [x] Continue             `c`
- [x] Run                      `r`


> [!NOTE]  
> Only the shorthand format for these are implemented. LLDB's command syntax technically supports more long form commands.
> See https://lldb.llvm.org/use/map.html