### PR TITLE
Fix launching process on Windows and pipe out/err to cout/cerr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,13 @@ set(TEST_SOURCES
 add_executable(${PROJECT_NAME}-test ${TEST_SOURCES})
 target_compile_features(${PROJECT_NAME}-test PRIVATE cxx_std_23)
 
+if(WIN32)
+  set(WIN32_TEST_SOURCES
+    test/launch_test_windows.cpp)
+  add_executable(launch-test-windows-test ${WIN32_TEST_SOURCES})
+  target_compile_features(launch-test-windows-test PRIVATE cxx_std_23)
+endif()
+
 include(cmake/Install.cmake)
 
 include(cmake/CPack.cmake)

--- a/src/LLDBDebugger.hpp
+++ b/src/LLDBDebugger.hpp
@@ -9,6 +9,7 @@ struct FileContext;
 #include <thread>
 #include <fmt/core.h>
 #include "LLDBCommandParser.hpp"
+#include "TempRedirect.hpp"
 
 class LLDBDebugger {
   public:
@@ -63,6 +64,13 @@ class LLDBDebugger {
     lldb::SBProcess process;
     lldb::SBListener listener;
     std::thread lldbEventThread;
+    TempRedirect in_redirect;
+    size_t in_offset = 0;
+    TempRedirect out_redirect;
+    size_t out_offset = 0;
+    TempRedirect err_redirect;
+    size_t err_offset = 0;
+    void DumpToStd(TempRedirect &redirect, std::ostream &out, size_t& offset);
 
   private:
     LLDB_CommandParser commandParser;

--- a/src/TempRedirect.cpp
+++ b/src/TempRedirect.cpp
@@ -1,0 +1,54 @@
+bool TempRedirect::Create(const char *prefix)
+{
+    if (file)
+        Close();
+#ifdef _WIN32
+    char tmp_path[MAX_PATH];
+    if (!GetTempPathA(MAX_PATH, tmp_path))
+        return false;
+
+    char tmp_filename[MAX_PATH];
+    if (!GetTempFileNameA(tmp_path, prefix, 0, tmp_filename))
+        return false;
+
+    path = tmp_filename;
+    fd = _open(tmp_filename, _O_RDWR | _O_BINARY);
+    if (fd == -1)
+        return false;
+
+    file = _fdopen(fd, "w+");
+    return file != nullptr;
+#else
+    char tmp_filename[] = "/tmp/lldb_io_XXXXXX";
+    fd = mkstemp(tmp_filename);
+    if (fd == -1)
+        return false;
+
+    path = tmp_filename;
+    file = fdopen(fd, "w+");
+    return file != nullptr;
+#endif
+}
+
+void TempRedirect::Close()
+{
+    if (file)
+    {
+        fclose(file);
+        file = nullptr;
+    }
+    else if (fd != -1)
+    {
+#ifdef _WIN32
+        _close(fd);
+#else
+        close(fd);
+#endif
+        fd = -1;
+    }
+}
+
+TempRedirect::~TempRedirect()
+{
+    Close();
+}

--- a/src/Tempredirect.hpp
+++ b/src/Tempredirect.hpp
@@ -1,0 +1,27 @@
+#include <string>
+#include <vector>
+#include <fstream>
+#include <cstdio>
+#include <cstdlib>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <io.h>
+#include <fcntl.h>
+#else
+#include <unistd.h>
+#include <fcntl.h>
+#endif
+
+struct TempRedirect
+{
+    std::string path;
+    int fd = -1;
+    FILE *file = nullptr;
+
+    bool Create(const char *prefix);
+
+    void Close();
+
+    ~TempRedirect();
+};

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -65,4 +65,58 @@ namespace Util {
 
     return exePath.parent_path();
   }
+  
+  std::string StringEscapeBackslash(const std::string& string)
+  {
+    std::string result;
+
+    // Reserve enough space: worst case all backslashes need escaping
+    result.reserve(string.size() * 2);
+
+    std::size_t i = 0;
+    const std::size_t length = string.size();
+
+    while (i < length)
+    {
+        if (string[i] == '\\')
+        {
+            // Count consecutive backslashes starting at i
+            std::size_t backslash_count = 0;
+
+            while (i + backslash_count < length && string[i + backslash_count] == '\\')
+            {
+                ++backslash_count;
+            }
+
+            // Number of full pairs
+            std::size_t pairs = backslash_count / 2;
+
+            // Copy all full pairs as-is (each pair is two backslashes)
+            for (std::size_t p = 0; p < pairs; ++p)
+            {
+                result.push_back('\\');
+                result.push_back('\\');
+            }
+
+            // If there is an odd one left (unescaped), escape it
+            if (backslash_count % 2 != 0)
+            {
+                // One unescaped backslash, so write two backslashes
+                result.push_back('\\');
+                result.push_back('\\');
+            }
+
+            // Move i forward by backslash_count
+            i += backslash_count;
+        }
+        else
+        {
+            // Normal character, just copy
+            result.push_back(string[i]);
+            ++i;
+        }
+    }
+
+    return result;
+  }
 }

--- a/src/Util.hpp
+++ b/src/Util.hpp
@@ -7,6 +7,7 @@ namespace Util {
   void PrintTargetModules(lldb::SBTarget& target);
   void PrintModuleCompileUnits(lldb::SBTarget& target, int moduleIdx);
   std::filesystem::path GetCurrentProgramDirectory();
+  std::string StringEscapeBackslash(const std::string& string);
 }
 
 #endif

--- a/src/lldb-frontend.cpp
+++ b/src/lldb-frontend.cpp
@@ -14,3 +14,4 @@
 #include "ImGuiLayer.hpp"
 #include "FileHeirarchy.hpp"
 #include "LLDBDebugger.hpp"
+#include "TempRedirect.cpp"

--- a/test/launch_test_windows.cpp
+++ b/test/launch_test_windows.cpp
@@ -1,0 +1,101 @@
+#include <windows.h>
+#include <iostream>
+#include <string>
+#include <vector>
+
+std::wstring ConvertToWString(const std::string &input)
+{
+    if (input.empty())
+        return std::wstring();
+
+    int size_needed = MultiByteToWideChar(CP_UTF8, 0, input.c_str(), (int)input.size(), NULL, 0);
+    std::wstring wstrTo(size_needed, 0);
+    MultiByteToWideChar(CP_UTF8, 0, input.c_str(), (int)input.size(), &wstrTo[0], size_needed);
+    return wstrTo;
+}
+
+int main()
+{
+    HANDLE stdout_read = nullptr;
+    HANDLE stdout_write = nullptr;
+
+    SECURITY_ATTRIBUTES saAttr = {};
+    saAttr.nLength = sizeof(SECURITY_ATTRIBUTES);
+    saAttr.bInheritHandle = TRUE;
+    saAttr.lpSecurityDescriptor = NULL;
+
+    if (!CreatePipe(&stdout_read, &stdout_write, &saAttr, 0))
+    {
+        std::cerr << "Failed to create stdout pipe\n";
+        return 1;
+    }
+
+    // Make read handle non-inheritable (only parent reads from it)
+    SetHandleInformation(stdout_read, HANDLE_FLAG_INHERIT, 0);
+
+    STARTUPINFOEX startupinfoex = {};
+    startupinfoex.StartupInfo.cb = sizeof(STARTUPINFOEX);
+    startupinfoex.StartupInfo.dwFlags |= STARTF_USESTDHANDLES;
+    startupinfoex.StartupInfo.hStdOutput = stdout_write;
+    startupinfoex.StartupInfo.hStdError = stdout_write;
+    startupinfoex.StartupInfo.hStdInput = GetStdHandle(STD_INPUT_HANDLE); // optional
+
+    SIZE_T attr_list_size = 0;
+    InitializeProcThreadAttributeList(NULL, 1, 0, &attr_list_size);
+    startupinfoex.lpAttributeList = (LPPROC_THREAD_ATTRIBUTE_LIST)malloc(attr_list_size);
+    InitializeProcThreadAttributeList(startupinfoex.lpAttributeList, 1, 0, &attr_list_size);
+
+    HANDLE handle_list[2] = { stdout_write, GetStdHandle(STD_INPUT_HANDLE) };
+    UpdateProcThreadAttribute(
+        startupinfoex.lpAttributeList, 0,
+        PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+        handle_list,
+        sizeof(handle_list),
+        nullptr,
+        nullptr);
+
+    PROCESS_INFORMATION pi = {};
+    std::wstring wexecutable = ConvertToWString("Z:\\Projects\\lldb-frontend\\build-windows\\Debug\\lldb-frontend-test.exe");
+    std::wstring wcommandLine = ConvertToWString("\"Z:\\Projects\\lldb-frontend\\build-windows\\Debug\\lldb-frontend-test.exe\"");
+    std::wstring wworkingDirectory = ConvertToWString("Z:\\Projects\\lldb-frontend\\build-windows\\Debug");
+    WCHAR *pwcommandLine = &wcommandLine[0];
+
+    BOOL result = CreateProcessW(
+        wexecutable.c_str(),
+        pwcommandLine,
+        NULL,
+        NULL,
+        TRUE, // inherit handles
+        EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT,
+        NULL,
+        wworkingDirectory.c_str(),
+        (LPSTARTUPINFOW)&startupinfoex,
+        &pi);
+
+    if (!result)
+    {
+        std::cerr << "CreateProcessW failed with error: " << GetLastError() << std::endl;
+        return 2;
+    }
+
+    CloseHandle(stdout_write); // Close write-end in parent
+
+    // Read child stdout
+    DWORD read = 0;
+    CHAR buffer[4096];
+    while (ReadFile(stdout_read, buffer, sizeof(buffer) - 1, &read, NULL) && read > 0)
+    {
+        buffer[read] = '\0';
+        std::cout << buffer;
+    }
+
+    WaitForSingleObject(pi.hProcess, INFINITE);
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+    CloseHandle(stdout_read);
+
+    DeleteProcThreadAttributeList(startupinfoex.lpAttributeList);
+    free(startupinfoex.lpAttributeList);
+
+    return 0;
+}

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 
-int main() {
+int main(int argc, const char **argv) {
+  std::cout << "argv[0]: " << argv[0] << std::endl;
   std::cout << "Hello world from test" << std::endl;
   std::cout << "Hello world from test" << std::endl;
   std::cout << "Hello world from test" << std::endl;


### PR DESCRIPTION
After some intense debug sessions I've found a fix for launching a lldb process on Windows. The key was to pass a valid stdX handle for in/out/err. For this, I have created `struct TempRedirect` which is cross platform compatible and creates a temp file for redirecting output.