### PR TITLE
Breakpoints code highlighting

### DIFF
--- a/src/ImGuiCustomWidgets.cpp
+++ b/src/ImGuiCustomWidgets.cpp
@@ -5,7 +5,7 @@
 #include <imgui.h>
 
 namespace ImGuiCustom {
-  void Breakpoint(int id, FileHeirarchy::HeirarchyElement& element, ImGuiLayer& imguiLayer) {
+  void Breakpoint(int id, FileHeirarchy::HeirarchyElement& element, ImGuiLayer& imguiLayer, bool active) {
     if (element.lines->empty()) return;
     ImVec2 cursorPos = ImGui::GetCursorScreenPos();
     float radius = 6.0f;
@@ -26,11 +26,14 @@ namespace ImGuiCustom {
     ImVec2 center = ImVec2(cursorPos.x + radius + 2, cursorPos.y + radius + 2);
 
     // Draw outer circle
-    drawList->AddCircle(center, radius, IM_COL32(255, 255, 255, 255), 16, 1.5f);
+    auto circle_color = active ? 
+      IM_COL32(248, 42, 128, 255) :
+      IM_COL32(255, 255, 255, 255);
+    drawList->AddCircle(center, radius, circle_color, 16, 1.5f);
 
     // If checked, draw filled circle
     if (element.lines->at(id).bp) {
-      drawList->AddCircleFilled(center, radius - 2.0f, IM_COL32(255, 255, 255, 255), 16);
+      drawList->AddCircleFilled(center, radius - 2.0f, circle_color, 16);
     }
   }
 }

--- a/src/ImGuiCustomWidgets.hpp
+++ b/src/ImGuiCustomWidgets.hpp
@@ -7,7 +7,7 @@ struct FileContext;
 struct ImGuiLayer;
 
 namespace ImGuiCustom {
-  void Breakpoint(int id, FileHeirarchy::HeirarchyElement& element, ImGuiLayer& imguiLayer);
+  void Breakpoint(int id, FileHeirarchy::HeirarchyElement& element, ImGuiLayer& imguiLayer, bool active);
 }
 
 #endif

--- a/src/ImGuiLayer.cpp
+++ b/src/ImGuiLayer.cpp
@@ -204,18 +204,24 @@ void ImGuiLayer::DrawDebugWindow() {
 }
 
 void ImGuiLayer::DrawCodeFile(FileHeirarchy::HeirarchyElement& element) {
+  bool active_file = debugger.IsActiveFile(element.full_path_string);
   if (element.lines->empty()) return;
   for (int i = 0; i < element.lines->size(); i++) {
     auto& line = element.lines->at(i);
     ImGui::PushID(i);
-    ImGuiCustom::Breakpoint(i, element, *this); ImGui::SameLine();
+    auto line_number = i + 1;
+    auto line_active = debugger.IsActiveLine(line_number);
+    ImGuiCustom::Breakpoint(i, element, *this, line_active); ImGui::SameLine();
     ImVec2 cursor = ImGui::GetCursorScreenPos();
     ImVec2 text_size = ImGui::CalcTextSize(line.line.c_str());
     ImVec2 line_size = ImVec2(ImGui::GetWindowWidth() - ImGui::GetStyle().WindowPadding.x * 1.75, text_size.y * 1.5);
+    auto line_bg_color = i % 2 == 0 ? ImGui::GetColorU32(ImGuiCol_Button) : ImGui::GetColorU32(ImGuiCol_ButtonHovered);
+    if (active_file && line_active)
+      line_bg_color = IM_COL32(248, 42, 128, 255);
     ImGui::GetWindowDrawList()->AddRectFilled(
         cursor,
         cursor + line_size,
-        i % 2 == 0 ? ImGui::GetColorU32(ImGuiCol_Button) : ImGui::GetColorU32(ImGuiCol_ButtonHovered),
+        line_bg_color,
         0.f);
     ImGui::Text("[%d] | %s", i, line.line.c_str());
     ImGui::PopID();

--- a/src/LLDBDebugger.hpp
+++ b/src/LLDBDebugger.hpp
@@ -48,7 +48,12 @@ class LLDBDebugger {
 
     bool AddBreakpoint(FileHeirarchy::HeirarchyElement&, int id);
     bool RemoveBreakpoint(FileHeirarchy::HeirarchyElement&, int id);
+  private:
+    void HitBreakpoint(lldb::break_id_t b_id);
+  public:
     BreakpointData& GetBreakpointData(lldb::break_id_t id);
+    bool IsActiveFile(const std::string& filename);
+    bool IsActiveLine(int line_number);
 
   public:
     ExecResult ExecCommand(const std::string&, FileHeirarchy&);
@@ -59,6 +64,7 @@ class LLDBDebugger {
   private:
     lldb::SBDebugger debugger;
     std::unordered_map<lldb::break_id_t, BreakpointData> id_breakpoint_data;
+    std::optional<BreakpointData> active_line;
 
     lldb::SBTarget target;
     lldb::SBProcess process;


### PR DESCRIPTION
This PR introduces a bunch of information printed when the debugger encounters a stop event. It also calls a new function `HitBreakpoint` if a breakpoint was the stop reason. From there it sets `active_line`, which is an `optional<BreakpointData>`. In `DrawCodeFile` I determine if the current drawn line is the active line and change colors. Also, when the program resumes `active_line` is reset