### PR TITLE
Lldb auto exec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 build-windows/
 _CPack_Packages
 *.tar.gz
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,3 +97,4 @@ include(cmake/CPack.cmake)
 
 include(cmake/imgui.ini.cmake)
 include(cmake/Resources.cmake)
+include(cmake/AutoExec.cmake)

--- a/autoexec_example
+++ b/autoexec_example
@@ -1,0 +1,4 @@
+b main
+b test.cpp:13
+b nested.cpp:5
+r

--- a/cmake/AutoExec.cmake
+++ b/cmake/AutoExec.cmake
@@ -1,0 +1,29 @@
+get_target_property(target_name lldb-frontend NAME)
+
+# Determine the output base depending on target type
+get_target_property(target_type ${target_name} TYPE)
+
+if(target_type STREQUAL "EXECUTABLE" OR target_type STREQUAL "UTILITY")
+    set(base_output_dir "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+elseif(target_type STREQUAL "STATIC_LIBRARY" OR target_type STREQUAL "SHARED_LIBRARY")
+    set(base_output_dir "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+else()
+    message(FATAL_ERROR "Unhandled target type: ${target_type}")
+endif()
+
+# If not set, use default
+if(NOT base_output_dir)
+    set(base_output_dir "${CMAKE_BINARY_DIR}")
+endif()
+
+# Add configuration subdir if using a multi-config generator
+if(CMAKE_CONFIGURATION_TYPES)
+    set(config "Debug") # Or your chosen configuration
+    set(LLDB_FRONTEND_BUILD_DIRECTORY "${base_output_dir}/${config}")
+else()
+    set(LLDB_FRONTEND_BUILD_DIRECTORY "${base_output_dir}")
+endif()
+
+message(STATUS "Output directory for ${target_name} will be: ${LLDB_FRONTEND_BUILD_DIRECTORY}")
+
+file(COPY autoexec_example DESTINATION ${LLDB_FRONTEND_BUILD_DIRECTORY})

--- a/src/Args.cpp
+++ b/src/Args.cpp
@@ -6,6 +6,8 @@ namespace lldb_frontend {
   void Args::SetupOptions() {
     parser.add_argument("--executable")
       .help("The program you wish to debug");
+    parser.add_argument("--autoexec")
+      .help("Script file containing autoexec instructions");
   }
 
   bool Args::Parse(int argc, char **argv) {

--- a/src/FileHierarchy.cpp
+++ b/src/FileHierarchy.cpp
@@ -1,5 +1,6 @@
 #include "FileHierarchy.hpp"
 #include "Logger.hpp"
+#include "Util.hpp"
 #include <iostream>
 #include <fstream>
 #if defined(_WIN32)
@@ -105,17 +106,9 @@ bool FileHierarchy::TreeNode::LoadFromDisk() {
   Logger::ScopedGroup g("TreeNode::LoadFromDisk");
   if (!lines.has_value()) {
     lines = std::vector<Line>{};
-    std::ifstream f(path);
-    if (!f.is_open()) {
-        Logger::Crit("Failed to load {} from disk", path.string());
-        return false;
+    if (Util::ReadFileLinesIntoVector(path.string(), lines.value())) {
+      Logger::Info("Loaded {} from disk", path.string());
     }
-    std::string line;
-    while (std::getline(f, line)) {
-        lines->push_back(Line{.line = line, .bp = false});
-    }
-    f.close();
-    Logger::Info("Loaded {} from disk", path.string());
   }
   return true;
 }
@@ -195,6 +188,14 @@ FileHierarchy::TreeNode& FileHierarchy::GetRoot() {
   return root;
 }
 
+FileHierarchy::TreeNode* FileHierarchy::GetElementByFilename(const std::string& filename) {
+  for (auto& [key, child] : root.children) {
+      auto found = GetElementByFilenameRec(child, filename);
+      if (found) return found;
+  }
+  return nullptr;
+}
+
 FileHierarchy::TreeNode* FileHierarchy::GetElementByLocalPath(const std::filesystem::path& localpath) {
   for (auto& [key, child] : root.children) {
       auto found = GetElementByLocalPathRec(child, localpath);
@@ -223,6 +224,15 @@ void FileHierarchy::ComputeTree()
     root.Insert(parts);
   }
   root.Print();
+}
+
+FileHierarchy::TreeNode* FileHierarchy::GetElementByFilenameRec(TreeNode& node, const std::string& filename) const {
+  if (node.name == filename) return &node;
+  for (auto& [key, child] : node.children) {
+      auto result = GetElementByFilenameRec(child, filename);
+      if (result) return result;
+  }
+  return nullptr;
 }
 
 FileHierarchy::TreeNode* FileHierarchy::GetElementByLocalPathRec(TreeNode& node, const std::filesystem::path& localpath) const {

--- a/src/FileHierarchy.cpp
+++ b/src/FileHierarchy.cpp
@@ -106,7 +106,7 @@ bool FileHierarchy::TreeNode::LoadFromDisk() {
   Logger::ScopedGroup g("TreeNode::LoadFromDisk");
   if (!lines.has_value()) {
     lines = std::vector<Line>{};
-    if (Util::ReadFileLinesIntoVector(path.string(), lines.value())) {
+    if (Util::ReadFileLinesIntoVector(path, lines.value())) {
       Logger::Info("Loaded {} from disk", path.string());
     }
   }

--- a/src/FileHierarchy.cpp
+++ b/src/FileHierarchy.cpp
@@ -236,7 +236,7 @@ FileHierarchy::TreeNode* FileHierarchy::GetElementByFilenameRec(TreeNode& node, 
 }
 
 FileHierarchy::TreeNode* FileHierarchy::GetElementByLocalPathRec(TreeNode& node, const std::filesystem::path& localpath) const {
-  if (node.GetPath() == localpath) return &node;
+  if (node.path == localpath) return &node;
   for (auto& [key, child] : node.children) {
       auto result = GetElementByLocalPathRec(child, localpath);
       if (result) return result;

--- a/src/FileHierarchy.hpp
+++ b/src/FileHierarchy.hpp
@@ -47,10 +47,12 @@ class FileHierarchy {
   public:
     void AddFile(const std::filesystem::path& path);
     TreeNode& GetRoot();
+    TreeNode* GetElementByFilename(const std::string& filename);
     TreeNode* GetElementByLocalPath(const std::filesystem::path& localpath);
     void ComputeTree();
 
   private:
+    TreeNode* GetElementByFilenameRec(TreeNode& node, const std::string& filename) const;
     TreeNode* GetElementByLocalPathRec(TreeNode& node, const std::filesystem::path& localpath) const;
 
   private:

--- a/src/ImGuiLayer.hpp
+++ b/src/ImGuiLayer.hpp
@@ -9,6 +9,7 @@ struct ImGuiInputTextCallbackData;
 class LLDBDebugger;
 
 class ImGuiLayer {
+  friend LLDBDebugger;
   public:
     ImGuiLayer(LLDBDebugger& debugger);
     ~ImGuiLayer();
@@ -20,9 +21,12 @@ class ImGuiLayer {
     LLDBDebugger& GetDebugger();
     FileHierarchy& GetFileHierarchy();
     void DrawFilesNotFoundModal();
+  
+  protected:
+    bool FrontendLoadFile(FileHierarchy::TreeNode&);
 
   private:
-    bool LoadFile(const std::filesystem::path&);
+    bool LoadFile(FileHierarchy::TreeNode&);
 
   private:
     void DrawDebugWindow();
@@ -46,7 +50,6 @@ class ImGuiLayer {
     LLDBDebugger& debugger;
     Window* window_ref;
     FileHierarchy fh;
-    std::unordered_map<std::string, FileContext> fileContentsMap;
     std::vector<FileHierarchy::TreeNode*> openFiles;
     bool m_FilesNotFoundModal_open = false;
     std::vector<const FileHierarchy::TreeNode*> m_FilesNotFoundModal_files;

--- a/src/LLDBDebugger.cpp
+++ b/src/LLDBDebugger.cpp
@@ -283,6 +283,11 @@ LLDBDebugger::ExecResult LLDBDebugger::ExecCommand(const std::string& command, F
         }
         break;
       }
+    case LLDB_CommandParser::ParsedCommandType::RUN:
+      {
+        LaunchTarget();
+        break;
+      }
     case LLDB_CommandParser::ParsedCommandType::STEP:
       {
         GetProcess().GetSelectedThread().StepInto();

--- a/src/LLDBDebugger.cpp
+++ b/src/LLDBDebugger.cpp
@@ -223,6 +223,7 @@ LLDBDebugger::ExecResult LLDBDebugger::ExecCommand(const std::string& command, F
           Logger::Err("File '{}' does not exist in target", bpfileline.file);
         }
         else {
+          imGuiLayer_ptr->FrontendLoadFile(*node);
           if (AddBreakpoint(*node, bpfileline.line)) {
             Logger::Info("Breakpoint in file '{}' line {}", bpfileline.file, bpfileline.line);
           }
@@ -269,6 +270,7 @@ LLDBDebugger::ExecResult LLDBDebugger::ExecCommand(const std::string& command, F
 
           auto path = std::filesystem::path(fs.GetDirectory()) / fs.GetFilename();
           if (auto node = fh.GetElementByLocalPath(path)) {
+            imGuiLayer_ptr->FrontendLoadFile(*node);
             if (AddBreakpoint(*node, lineno)) {
               Logger::Info("Break on symbol {} in {}", bpsymbol.symbol, fs.GetFilename());
             }

--- a/src/LLDBDebugger.hpp
+++ b/src/LLDBDebugger.hpp
@@ -11,7 +11,10 @@ struct FileContext;
 #include "LLDBCommandParser.hpp"
 #include "TempRedirect.hpp"
 
+class ImGuiLayer;
+
 class LLDBDebugger {
+  friend Window;
   public:
     enum class ExecResultStatus {
       Ok,
@@ -77,6 +80,9 @@ class LLDBDebugger {
     TempRedirect err_redirect;
     size_t err_offset = 0;
     void DumpToStd(TempRedirect &redirect, std::ostream &out, size_t& offset);
+
+  protected:
+    ImGuiLayer* imGuiLayer_ptr = 0;
 
   private:
     LLDB_CommandParser commandParser;

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -1,6 +1,8 @@
 #include "Util.hpp"
+#include "FileContext.hpp"
 #include "Logger.hpp"
 #include <iostream>
+#include <fstream>
 #if defined(_WIN32)
 #include <windows.h>
 #elif defined(__APPLE__)
@@ -9,6 +11,7 @@
 #include <unistd.h>
 #endif
 
+struct Line;
 namespace Util {
   void PrintTargetModules(lldb::SBTarget& target) {
     Logger::ScopedGroup g("PrintTargetModules");
@@ -155,5 +158,20 @@ namespace Util {
         at_root = true;
     }
     return std::nullopt;
+  }
+
+  bool ReadFileLinesIntoVector(const std::string &filepath, std::vector<Line>& lines) {
+    std::ifstream f(filepath);
+    if (!f.is_open()) {
+      Logger::Crit("Failed to load {} from disk", filepath);
+      f.close();
+      return false;
+    }
+    std::string line;
+    while (std::getline(f, line)) {
+      lines.push_back(Line{.line = line, .bp = false});
+    }
+    f.close();
+    return true;
   }
 }

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -160,10 +160,10 @@ namespace Util {
     return std::nullopt;
   }
 
-  bool ReadFileLinesIntoVector(const std::string &filepath, std::vector<Line>& lines) {
+  bool ReadFileLinesIntoVector(const std::filesystem::path& filepath, std::vector<Line>& lines) {
     std::ifstream f(filepath);
     if (!f.is_open()) {
-      Logger::Crit("Failed to load {} from disk", filepath);
+      Logger::Crit("Failed to load {} from disk", filepath.string());
       f.close();
       return false;
     }

--- a/src/Util.hpp
+++ b/src/Util.hpp
@@ -4,12 +4,15 @@
 #include <filesystem>
 #include <optional>
 
+struct Line;
 namespace Util {
   void PrintTargetModules(lldb::SBTarget& target);
   void PrintModuleCompileUnits(lldb::SBTarget& target, int moduleIdx);
   std::filesystem::path GetCurrentProgramDirectory();
   std::string StringEscapeBackslash(const std::string& string);
   std::optional<std::filesystem::path> GetTargetSourceRootDirectory(std::filesystem::path start_dir);
+
+  bool ReadFileLinesIntoVector(const std::string& filepath, std::vector<Line>& lines);
 }
 
 #endif

--- a/src/Util.hpp
+++ b/src/Util.hpp
@@ -12,7 +12,7 @@ namespace Util {
   std::string StringEscapeBackslash(const std::string& string);
   std::optional<std::filesystem::path> GetTargetSourceRootDirectory(std::filesystem::path start_dir);
 
-  bool ReadFileLinesIntoVector(const std::string& filepath, std::vector<Line>& lines);
+  bool ReadFileLinesIntoVector(const std::filesystem::path& filepath, std::vector<Line>& lines);
 }
 
 #endif

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -73,7 +73,7 @@ Window::Window(const std::string& title, int width, int height):
         auto result = debuggerCtx.ExecCommand(line.line, fh);
       }
     }
-.  }
+  }
 _exit:
   Logger::Info("Created window");
 }


### PR DESCRIPTION
# Feature
This PR features the ability to provide a path to a file from the command line in the following fashion.
Upon launch the main executable target will launch, and then the commands in the autoexec are forwarded to the debugger to:
- create breakpoints
- run the program
- etc...
Any command normally supported will function here.

```
Usage:  [--help] [--version] [--executable VAR] [--autoexec VAR]

Optional arguments:
  -h, --help     shows help message and exits 
  -v, --version  prints version information and exits 
  --executable   The program you wish to debug 
  --autoexec     Script file containing autoexec instructions 
```

It's most useful when an `--executable` is provided as well.

# Build
For build I provided a configure script that puts a sample `autoexec` in the build folder ready to use alongside the example executable.


# Example Usage
```bash
./lldb-frontend --executable lldb-frontend-test --autoexec autoexec_example
```
