### PR TITLE
Fixed problem where running process didnt get killed on window close

### DIFF
--- a/src/LLDBDebugger.cpp
+++ b/src/LLDBDebugger.cpp
@@ -22,7 +22,10 @@ LLDBDebugger::LLDBDebugger() {
 }
 
 LLDBDebugger::~LLDBDebugger() {
-  target.GetProcess().Kill();           // TODO: We have a problem where the running thread keeps the main process from closing
+  auto error = process.Kill();           // TODO: We have a problem where the running thread keeps the main process from closing
+  if (error.Fail()) {
+    Logger::Crit("Failed to kill process. Reason {}", error.GetCString());
+  }
   lldb::SBDebugger::Destroy(debugger);
   lldb::SBDebugger::Terminate();
   if (lldbEventThread.joinable())

--- a/src/LLDBDebugger.cpp
+++ b/src/LLDBDebugger.cpp
@@ -22,7 +22,7 @@ LLDBDebugger::LLDBDebugger() {
 }
 
 LLDBDebugger::~LLDBDebugger() {
-  auto error = process.Kill();           // TODO: We have a problem where the running thread keeps the main process from closing
+  auto error = process.Kill();
   if (error.Fail()) {
     Logger::Crit("Failed to kill process. Reason {}", error.GetCString());
   }


### PR DESCRIPTION
We were killing the process incorrectly, which prevented lldb from sending the right event to the event loop.